### PR TITLE
feat(pos): add admin restriction for payment methods

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -10,16 +10,19 @@
     'description': """
 
 """,
+    'license': 'LGPL-3',
     'depends': ['base','point_of_sale'],
     'data': [
         'views/pos_config_view.xml',
         'views/pos_order_views.xml',
-        # 'security/ir.model.access.csv',
+        'views/pos_payment_method_views.xml',
+        'security/ir.model.access.csv',
     ],
     'assets':{
         'point_of_sale.assets': [
             'pos_netpay_connector/static/src/js/pos_netpay_connector.js',
             'pos_netpay_connector/static/src/js/payment_netpay.js',
+            'pos_netpay_connector/static/src/js/payment_lines_patch.js',
         ],
     },
     'installable': True,

--- a/models/order_transaction.py
+++ b/models/order_transaction.py
@@ -4,6 +4,7 @@ from odoo import api, fields, models, _
 
 class PosOrderT(models.Model):
     _name = 'netpay.transaction'
+    _description = 'Netpay transaction'
 
     name = fields.Char('Nombre')
     payid = fields.Char('payid')

--- a/models/pos_payment_method.py
+++ b/models/pos_payment_method.py
@@ -33,6 +33,7 @@ class PosPaymentMethod(models.Model):
     terminal_api_key = fields.Char('API Key')
     terminal_api_pwd = fields.Char('API Password')
     terminal_id = fields.Char('Terminal ID')
+    administrators_only = fields.Boolean(string="Solo administradores", default=False)
 
 
     def proxy_netpay_request(self, data, operation):

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+pos_netpay_connector.access_netpay_transaction,access_netpay_transaction,pos_netpay_connector.model_netpay_transaction,base.group_user,1,1,1,1

--- a/security/ir.model.access.csvZone.Identifier
+++ b/security/ir.model.access.csvZone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3

--- a/static/src/js/payment_lines_patch.js
+++ b/static/src/js/payment_lines_patch.js
@@ -1,0 +1,36 @@
+odoo.define('pos_netpay_connector.payment_lines_patch', function(require) {
+    'use strict';
+
+    const PaymentScreenPaymentLines = require('point_of_sale.PaymentScreenPaymentLines');
+    const Registries = require('point_of_sale.Registries');
+    const { Gui } = require('point_of_sale.Gui');
+
+    const PatchedPaymentLines = PaymentScreenPaymentLines => 
+        class extends PaymentScreenPaymentLines {
+            selectedLineClass(line) {
+                const paymentMethod = line.payment_method;
+                const order = line.order;
+                const userIsAdmin = order.pos.user.role === 'manager';
+
+                if (paymentMethod.administrators_only && !userIsAdmin) {
+                    // Mostrar el popup de error
+                    Gui.showPopup('ErrorPopup', {
+                        title: 'Acceso restringido',
+                        body: `El método de pago "${paymentMethod.name}" solo está disponible para administradores.`,
+                    }).then(() => {
+                        // Eliminar la línea de pago no autorizada
+                        order.remove_paymentline(line);
+                        // Forzar la actualización de la vista
+                        this.render();
+                    });
+                    
+                    return {}; // No aplicar estilos de selección
+                }
+
+                return super.selectedLineClass(line);
+            }
+        };
+
+    Registries.Component.extend(PaymentScreenPaymentLines, PatchedPaymentLines);
+    return PaymentScreenPaymentLines;
+});

--- a/static/src/js/pos_netpay_connector.js
+++ b/static/src/js/pos_netpay_connector.js
@@ -3,7 +3,7 @@ odoo.define('pos_netpay_connector.models', function(require) {
     var PaymentTerminal = require('pos_netpay_connector.payment');
 
     models.register_payment_method('netpay', PaymentTerminal);
-    models.load_fields('pos.payment.method', ['terminal_api_key', 'terminal_api_pwd', 'terminal_id']);
+    models.load_fields('pos.payment.method', ['terminal_api_key', 'terminal_api_pwd', 'terminal_id', 'administrators_only']);
 
    var _payterminal = models.Paymentline.prototype;
    //var _payecoduit = models.Paymentline.prototype

--- a/views/pos_order_views.xml
+++ b/views/pos_order_views.xml
@@ -62,7 +62,7 @@
   </record>
 
 
-    <record id="pos_payment_method_view_form_inherit_pos_econduit" model="ir.ui.view">
+    <!-- <record id="pos_payment_method_view_form_inherit_pos_econduit" model="ir.ui.view">
         <field name="name">pos.payment.method.form.inherit.terminal</field>
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
@@ -84,6 +84,6 @@
 
            </xpath>
         </field>
-    </record>
+    </record> -->
 
 </odoo>

--- a/views/pos_payment_method_views.xml
+++ b/views/pos_payment_method_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pos_payment_method_view_inherit_netpay" model="ir.ui.view">
+        <field name="name">pos.payment.method.view.inherit.netpay</field>
+        <field name="model">pos.payment.method</field>
+        <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+                <field name="terminal_api_key"
+                            attrs="{'invisible': [('use_payment_terminal', '!=', 'netpay')],
+                                        'required': [('use_payment_terminal', '=', 'netpay')]}"/>
+                <field name="terminal_api_pwd" password="True"
+                            attrs="{'invisible': [('use_payment_terminal', '!=', 'netpay')],
+                                        'required': [('use_payment_terminal', '=', 'netpay')]}"/>
+                <field name="terminal_id"
+                            attrs="{'invisible': [('use_payment_terminal', '!=', 'netpay')],
+                                        'required': [('use_payment_terminal', '=', 'netpay')]}"/>
+                <field name="netpay_terminal_identifier"
+                            attrs="{'invisible': [('use_payment_terminal', '!=', 'netpay')],
+                                        'required': [('use_payment_terminal', '=', 'netpay')]}"/>
+                <field name="netpay_latest_response"/>
+           </xpath>
+           <field name="journal_id" position="after">
+                <field name="administrators_only"/>
+           </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added 'administrators_only' boolean field to pos.payment.method
- Implemented JS validation to restrict payment methods to admin users
- Show ErrorPopup and auto-remove payment line when unauthorized access attempted
- Extended PaymentScreenPaymentLines to handle admin validation logic